### PR TITLE
Number generalisation foundations

### DIFF
--- a/src/lmr/flowgradients.d
+++ b/src/lmr/flowgradients.d
@@ -136,16 +136,24 @@ public:
     @nogc
     void accumulate_values_from(in FlowGradients other)
     {
-        foreach (i; 0 .. 3) { vel[i][] += other.vel[i][]; }
-        version(multi_species_gas) {
-            foreach (isp; 0 .. massf.length) { massf[isp][] += other.massf[isp][]; }
+        foreach (i; 0 .. 3) {
+            foreach (j; 0 .. 3) vel[i][j] += other.vel[i][j];
         }
-        T[] += other.T[];
+        version(multi_species_gas) {
+            foreach (isp; 0 .. massf.length) { 
+                foreach (j; 0 .. 3) massf[isp][j] += other.massf[isp][j];
+            }
+        }
+        foreach (j; 0 .. 3) T[j] += other.T[j];
         version(multi_T_gas) {
-            foreach (imode; 0 .. T_modes.length) { T_modes[imode][] += other.T_modes[imode][]; }
+            foreach (imode; 0 .. T_modes.length) { 
+                foreach (j; 0 .. 3) T_modes[imode][j] += other.T_modes[imode][j];
+            }
         }
         version(turbulence) {
-            foreach(i; 0 .. turb.length) turb[i][] += other.turb[i][];
+            foreach(i; 0 .. turb.length) {
+                foreach (j; 0 .. 3) turb[i][j] += other.turb[i][j];
+            }
         }
     }
 

--- a/src/ntypes/complex.d
+++ b/src/ntypes/complex.d
@@ -260,6 +260,13 @@ if (isFloatingPoint!T)
         return this;
     }
 
+    // CASTING OPERATORS
+
+    R opCast(R : T)() const
+    {
+        return re;
+    }
+
     // COMPARISON OPERATORS
 
     // For the opEquals comparison operators, we only want the real component to be checked,

--- a/src/ntypes/complex.d
+++ b/src/ntypes/complex.d
@@ -552,6 +552,15 @@ if (isFloatingPoint!T)
 
 }
 
+@("Test casting")
+@safe pure nothrow unittest
+{
+    auto c1 = complex(1.0, 1.0);
+    auto c2 = cast(double) c1;
+    assert(is(typeof(c2) == double));
+    assert(c2 == 1.0);
+}
+
 @safe pure nothrow unittest
 {
     import std.complex;

--- a/src/util/lua.d
+++ b/src/util/lua.d
@@ -1,7 +1,5 @@
 module util.lua;
 
-import ntypes.complex;
-void lua_pushnumber(lua_State* L, Complex!double n) { lua_pushnumber(L, n.re); }
 
 // A.M.M - 01/12/2023
 // Create a trait that allows us to check if a type can be cast to another.
@@ -78,7 +76,7 @@ const LUA_GCSETSTEPMUL = 7;
 
 struct lua_State {}
 alias int function(lua_State* L) lua_CFunction;
-alias int  function(lua_State *L, int status, lua_KContext ctx) lua_KFunction;
+alias int function(lua_State *L, int status, lua_KContext ctx) lua_KFunction;
 
 alias double lua_Number;
 alias int lua_KContext;
@@ -95,6 +93,8 @@ void lua_replace(lua_State* L, int idx);
 
 void lua_pushnil(lua_State* L);
 void lua_pushnumber(lua_State* L, lua_Number n);
+// Templated version, to allow for Complex and Dual numbers without coupling packages
+void lua_pushnumber(T)(lua_State* L, T n) if (canCastTo!(T, lua_Number)) { lua_pushnumber(L, cast(lua_Number) n); }
 void lua_pushinteger(lua_State* L, lua_Integer n);
 void lua_pushstring(lua_State* L, const(char)* s);
 void lua_pushcclosure(lua_State* L, lua_CFunction fn, int n);

--- a/src/util/lua.d
+++ b/src/util/lua.d
@@ -3,6 +3,21 @@ module util.lua;
 import ntypes.complex;
 void lua_pushnumber(lua_State* L, Complex!double n) { lua_pushnumber(L, n.re); }
 
+// A.M.M - 01/12/2023
+// Create a trait that allows us to check if a type can be cast to another.
+// We require this, as the traditional "isFloatingPoint" cannot be extended
+// to custom types, such as Complex and Dual. 
+public template canCastTo(T, U) {
+    import std.traits : ReturnType;
+    // Check if T can be implicitly or explicitly cast to U
+    // A more complete version will hijack the `to!` checks
+    static if ( is(T : U) || is(ReturnType!(T.opCast!U) == U) ) {
+        enum canCastTo = true;
+    } else {
+        enum canCastTo = false;
+    }
+}
+
 extern (C):
 
 const LUAI_MAXSTACK = 1000000;

--- a/src/util/lua.d
+++ b/src/util/lua.d
@@ -53,7 +53,7 @@ unittest {
 
 extern (C):
 
-const LUAI_MAXSTACK = 1000000;
+const LUAI_MAXSTACK = 1_000_000;
 
 
 const LUA_REGISTRYINDEX = -LUAI_MAXSTACK - 1000;
@@ -75,12 +75,13 @@ const LUA_GCSETPAUSE = 6;
 const LUA_GCSETSTEPMUL = 7;
 
 struct lua_State {}
-alias int function(lua_State* L) lua_CFunction;
-alias int function(lua_State *L, int status, lua_KContext ctx) lua_KFunction;
+alias lua_CFunction = int function(lua_State* L);
+alias lua_KFunction = int function(lua_State *L, int status, lua_KContext ctx);
 
-alias double lua_Number;
-alias int lua_KContext;
-alias ptrdiff_t lua_Integer;
+alias lua_Number = double;
+alias lua_KContext = int;
+alias lua_Integer = ptrdiff_t;
+
 void lua_close(lua_State* L);
 int lua_gettop(lua_State* L) nothrow;
 void lua_settop(lua_State *L, int idx) nothrow;
@@ -139,7 +140,7 @@ bool lua_isfunction(lua_State* L, int n) { return lua_type(L, n) == LUA_TFUNCTIO
 lua_Number lua_tonumberx(lua_State *L, int idx, int *isnum);
 lua_Number lua_tonumber(lua_State *L, int idx) {return lua_tonumberx(L,idx,null);}
 lua_Integer lua_tointegerx(lua_State* L, int idx, int *pisnum);
-lua_Integer lua_tointeger(lua_State* L, int idx){return lua_tointegerx(L,idx,null);};
+lua_Integer lua_tointeger(lua_State* L, int idx){return lua_tointegerx(L,idx,null);}
 bool lua_toboolean(lua_State* L, int idx);
 const(char)* lua_tostring(lua_State* L, int i) { return lua_tolstring(L, i, null); }
 size_t lua_rawlen (lua_State *L, int idx);

--- a/src/util/lua.d
+++ b/src/util/lua.d
@@ -18,6 +18,41 @@ public template canCastTo(T, U) {
     }
 }
 
+@("canCastTo Trait")
+unittest {
+    struct MyType(T) {
+        T inner;
+
+        R opCast(R : T)() const {
+            return inner;
+        }
+    }
+
+    auto value = MyType!(double)(1.0);
+    auto casted = cast(double)(value);
+    assert( is(typeof(value) == MyType!double) );
+    assert( is(typeof(casted) == double) );
+
+    static assert(canCastTo!(MyType!double, double));
+    static assert(canCastTo!(MyType!float, float));
+    static assert(canCastTo!(MyType!double, float));
+    static assert(canCastTo!(MyType!float, double));
+
+    static assert(canCastTo!(double, double));
+    static assert(canCastTo!(float, double));
+    static assert(canCastTo!(double, float));
+
+    int i1 = 1;
+    double d1 = cast(double) i1;
+    assert( is(typeof(d1) == double) );
+    assert( d1 == 1.0 );
+    
+    static assert(canCastTo!(int, double));
+    static assert(canCastTo!(char, double));
+    static assert(canCastTo!(bool, double));
+    static assert(!canCastTo!(string, double));
+}
+
 extern (C):
 
 const LUAI_MAXSTACK = 1000000;

--- a/src/util/lua_service.d
+++ b/src/util/lua_service.d
@@ -14,7 +14,6 @@ import std.stdio;
 import std.string;
 import std.conv;
 import std.algorithm;
-import ntypes.complex;
 
 import util.lua;
 
@@ -310,7 +309,11 @@ void getArrayOfStrings(lua_State* L, string key, out string[] values)
  * Get named array of numbers from index in Lua stack.
  */
 
-void getArrayOfDoubles(lua_State* L, int tblIdx, string key, out double[] values)
+void getArrayOfDoubles(T)(lua_State* L, int tblIdx, string key, out T[] values)
+    // NOTE: This checks if we can cast T -> double, which isn't exactly what
+    //       we want, but it's a reasonable assumption for now. 
+    //       A better method will check if `to!` is valid, but `to!` is *very* powerful
+    if (canCastTo!(T, double))
 {
     int old_top = lua_gettop(L);
     if (!lua_istable(L, tblIdx)) {
@@ -327,32 +330,7 @@ void getArrayOfDoubles(lua_State* L, int tblIdx, string key, out double[] values
     auto n = to!int(lua_objlen(L, -1));
     foreach ( i; 1..n+1 ) {
         lua_rawgeti(L, -1, i);
-        if ( lua_isnumber(L, -1) ) values ~= lua_tonumber(L, -1);
-        // Silently ignore anything that isn't a value.
-        lua_pop(L, 1);
-    }
-    lua_pop(L, 1);
-    warnOnStackChange(L, old_top);
-}
-
-void getArrayOfDoubles(lua_State* L, int tblIdx, string key, out Complex!double[] values)
-{
-    int old_top = lua_gettop(L);
-    if (!lua_istable(L, tblIdx)) {
-        string errMsg = format("getArrayOfDoubles was expecting a table at stack index: %d", tblIdx);
-        throw new Error(errMsg);
-    }
-    values.length = 0;
-    lua_getfield(L, tblIdx, key.toStringz);
-    if ( !lua_istable(L, -1) ) {
-        string errMsg = format("A table of numbers was expected in field: %s", key);
-        lua_pop(L, 1);
-        throw new Error(errMsg);
-    }
-    auto n = to!int(lua_objlen(L, -1));
-    foreach ( i; 1..n+1 ) {
-        lua_rawgeti(L, -1, i);
-        if ( lua_isnumber(L, -1) ) values ~= to!(Complex!double)(lua_tonumber(L, -1));
+        if ( lua_isnumber(L, -1) ) values ~= to!(T)(lua_tonumber(L, -1));
         // Silently ignore anything that isn't a value.
         lua_pop(L, 1);
     }
@@ -389,7 +367,7 @@ void getArrayOfInts(lua_State* L, int tblIdx, string key, out int[] values)
     warnOnStackChange(L, old_top);
 }
 
-void getAssocArrayOfDoubles(lua_State* L, string key, string[] pList, out double[string] params)
+void getAssocArrayOfDoubles(T)(lua_State* L, string key, string[] pList, out T[string] params)
 {
     int old_top = lua_gettop(L);
     if (!lua_istable(L, -1)) {
@@ -403,27 +381,7 @@ void getAssocArrayOfDoubles(lua_State* L, string key, string[] pList, out double
         throw new Error(errMsg);
     }
     foreach (p; pList) {
-        params[p] = getDouble(L, -1, p);
-    }
-    lua_pop(L, 1);
-    warnOnStackChange(L, old_top);
-}
-
-void getAssocArrayOfDoubles(lua_State* L, string key, string[] pList, out Complex!double[string] params)
-{
-    int old_top = lua_gettop(L);
-    if (!lua_istable(L, -1)) {
-        string errMsg = format("getAssocArrayOfDoubles was expecting a table at stack index: %d", -1);
-        throw new Error(errMsg);
-    }
-    lua_getfield(L, -1, key.toStringz);
-    if ( !lua_istable(L, -1) ) {
-        string errMsg = format("A table with key and values (doubles) was expected in field: %s", key);
-        lua_pop(L, 1);
-        throw new Error(errMsg);
-    }
-    foreach (p; pList) {
-        params[p] = Complex!double(getDouble(L, -1, p), 0.0);
+        params[p] = to!(T)(getDouble(L, -1, p));
     }
     lua_pop(L, 1);
     warnOnStackChange(L, old_top);


### PR DESCRIPTION
Resolves the cyclic dependency of `util` and `ntypes`, by creating a trait to check if a type `T` can be cast to a type `U` (either implicitly or explicitly with `cast(U) T`). This allows lua functions to be general over a templated type `T`, and then cast to `lua_Number`. An overload for `Complex!T` is provided that gives the real component when casting to `T`. 

On top of decoupling the two modules, this allows for expansion / transition to using a dual number type, if it also implements `opCast`. 

_**Notes**_:
- The current version of DLang cannot correctly resolve types when using a combination of `ref const` (or `in`) and vectorized array operations on `T[]` if the element type `T` overloads `opCast`. This lead to the diff in `src/lmr/flowgradients.d`, where vectorized array operations are unrolled. 

_**Future work**_:

- [ ] Currently `lua_service` uses `canCastTo` as a workaround, as it internally calls [`to!`](https://dlang.org/phobos/std_conv.html#to), which has many overloads and is rather powerful. Hijacking the static checks used here would provide a much more flexible solution. 