### PR TITLE
(WIP) Allow parallel and incremental compilation for lmr (out-of-tree as well)

### DIFF
--- a/extern/lua-5.4.3/lpeg-1.0.2/parallel.make
+++ b/extern/lua-5.4.3/lpeg-1.0.2/parallel.make
@@ -1,0 +1,65 @@
+LIBNAME = lpeg
+LUADIR = ../src/
+
+# Build directory for out-of-tree builds (default "build")
+LP_BUILD_DIR ?= build
+
+COPT = -O2 -DNDEBUG
+# COPT = -g
+
+CWARNS = -Wall -Wextra -pedantic \
+	-Waggregate-return \
+	-Wcast-align \
+	-Wcast-qual \
+	-Wdisabled-optimization \
+	-Wpointer-arith \
+	-Wshadow \
+	-Wsign-compare \
+	-Wundef \
+	-Wwrite-strings \
+	-Wbad-function-cast \
+	-Wdeclaration-after-statement \
+	-Wmissing-prototypes \
+	-Wnested-externs \
+	-Wstrict-prototypes
+# -Wunreachable-code \
+
+CFLAGS = $(CWARNS) $(COPT) -std=c99 -I$(LUADIR) -fPIC
+CC = gcc
+
+# List of object files, now in LP_BUILD_DIR
+OBJS = $(LP_BUILD_DIR)/lpvm.o $(LP_BUILD_DIR)/lpcap.o $(LP_BUILD_DIR)/lptree.o $(LP_BUILD_DIR)/lpcode.o $(LP_BUILD_DIR)/lpprint.o
+
+# For Linux: builds shared library with Linux-specific flags.
+linux:
+	$(MAKE) -f parallel.make $(LP_BUILD_DIR)/lpeg.so "DLLFLAGS = -shared -fPIC"
+
+# For Mac OS: builds shared library with Mac-specific flags.
+macosx:
+	$(MAKE) -f parallel.make $(LP_BUILD_DIR)/lpeg.so "DLLFLAGS = -bundle -undefined dynamic_lookup"
+
+# Build shared library in LP_BUILD_DIR
+$(LP_BUILD_DIR)/lpeg.so: $(OBJS)
+	env $(CC) $(DLLFLAGS) $(OBJS) -o $(LP_BUILD_DIR)/lpeg.so
+
+# Pattern rule to compile .c files into .o files in LP_BUILD_DIR.
+$(LP_BUILD_DIR)/%.o: %.c
+	@mkdir -p $(LP_BUILD_DIR)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+# Force objects to rebuild if the makefile changes.
+$(OBJS): makefile
+
+# If your test expects lpeg.so in the current directory, adjust this target as needed.
+test: test.lua re.lua $(LP_BUILD_DIR)/lpeg.so
+	./test.lua
+
+clean:
+	rm -rf $(LP_BUILD_DIR)
+
+# Dependency rules updated for the build directory.
+$(LP_BUILD_DIR)/lpcap.o: lpcap.c lpcap.h lptypes.h
+$(LP_BUILD_DIR)/lpcode.o: lpcode.c lptypes.h lpcode.h lptree.h lpvm.h lpcap.h
+$(LP_BUILD_DIR)/lpprint.o: lpprint.c lptypes.h lpprint.h lptree.h lpvm.h lpcap.h
+$(LP_BUILD_DIR)/lptree.o: lptree.c lptypes.h lpcap.h lpcode.h lptree.h lpvm.h lpprint.h
+$(LP_BUILD_DIR)/lpvm.o: lpvm.c lpcap.h lptypes.h lpvm.h lpprint.h lptree.h

--- a/extern/lua-5.4.3/src/parallel.make
+++ b/extern/lua-5.4.3/src/parallel.make
@@ -1,0 +1,208 @@
+# Modified Makefile for building Lua into a specified build directory.
+# Build directory is specified by the make variable LUA_BUILD_DIR (default is "build")
+LUA_BUILD_DIR ?= build
+
+# == CHANGE THE SETTINGS BELOW TO SUIT YOUR ENVIRONMENT =======================
+
+# Your platform. See PLATS for possible values.
+PLAT= guess
+
+CC= gcc -std=gnu99
+CFLAGS= -O2 -Wall -Wextra -DLUA_COMPAT_5_3 $(SYSCFLAGS) $(MYCFLAGS)
+LDFLAGS= $(SYSLDFLAGS) $(MYLDFLAGS)
+LIBS= -lm $(SYSLIBS) $(MYLIBS)
+
+AR= ar rcu
+RANLIB= ranlib
+RM= rm -f
+UNAME= uname
+
+SYSCFLAGS=
+SYSLDFLAGS=
+SYSLIBS=
+
+MYCFLAGS=
+MYLDFLAGS=
+MYLIBS=
+MYOBJS=
+
+MAKEF = $(MAKE) -f parallel.make
+
+# Special flags for compiler modules; -Os reduces code size.
+CMCFLAGS=
+
+# == END OF USER SETTINGS -- NO NEED TO CHANGE ANYTHING BELOW THIS LINE =======
+
+PLATS= guess aix bsd c89 freebsd generic linux linux-readline macosx mingw posix solaris
+
+# All files are built in the build directory (OBJ_DIR)
+OBJ_DIR= $(LUA_BUILD_DIR)
+
+# Targets (all files are prefixed with OBJ_DIR)
+LUA_A= $(OBJ_DIR)/liblua.a
+CORE_O= $(OBJ_DIR)/lapi.o $(OBJ_DIR)/lcode.o $(OBJ_DIR)/lctype.o $(OBJ_DIR)/ldebug.o $(OBJ_DIR)/ldo.o $(OBJ_DIR)/ldump.o $(OBJ_DIR)/lfunc.o $(OBJ_DIR)/lgc.o $(OBJ_DIR)/llex.o $(OBJ_DIR)/lmem.o $(OBJ_DIR)/lobject.o $(OBJ_DIR)/lopcodes.o $(OBJ_DIR)/lparser.o $(OBJ_DIR)/lstate.o $(OBJ_DIR)/lstring.o $(OBJ_DIR)/ltable.o $(OBJ_DIR)/ltm.o $(OBJ_DIR)/lundump.o $(OBJ_DIR)/lvm.o $(OBJ_DIR)/lzio.o
+
+LIB_O= $(OBJ_DIR)/lauxlib.o $(OBJ_DIR)/lbaselib.o $(OBJ_DIR)/lcorolib.o $(OBJ_DIR)/ldblib.o $(OBJ_DIR)/liolib.o $(OBJ_DIR)/lmathlib.o $(OBJ_DIR)/loadlib.o $(OBJ_DIR)/loslib.o $(OBJ_DIR)/lstrlib.o $(OBJ_DIR)/ltablib.o $(OBJ_DIR)/lutf8lib.o $(OBJ_DIR)/linit.o
+
+BASE_O= $(CORE_O) $(LIB_O) $(MYOBJS)
+
+# RJG, 2021-11-15: Change executable name to clash with system Lua
+LUA_T= $(OBJ_DIR)/dgd-lua
+LUA_O= $(OBJ_DIR)/lua.o
+
+# RJG, 2021-11-15: Change executable name to clash with system Lua
+LUAC_T= $(OBJ_DIR)/dgd-luac
+LUAC_O= $(OBJ_DIR)/luac.o
+
+ALL_O= $(BASE_O) $(LUA_O) $(LUAC_O)
+ALL_T= $(LUA_A) $(LUA_T) $(LUAC_T)
+ALL_A= $(LUA_A)
+
+# Pattern rule: compile any .c file into an object in the build directory.
+$(OBJ_DIR)/%.o: %.c
+	@mkdir -p $(OBJ_DIR)
+	$(CC) $(CFLAGS) $(CMCFLAGS) -c $< -o $@
+
+# Targets start here.
+default: $(PLAT)
+
+all:	$(ALL_T)
+
+o:	$(ALL_O)
+
+a:	$(ALL_A)
+
+$(LUA_A): $(BASE_O)
+	$(AR) $@ $(BASE_O)
+	$(RANLIB) $@
+
+$(LUA_T): $(LUA_O) $(LUA_A)
+	$(CC) -o $@ $(LDFLAGS) $(LUA_O) $(LUA_A) $(LIBS)
+
+$(LUAC_T): $(LUAC_O) $(LUA_A)
+	$(CC) -o $@ $(LDFLAGS) $(LUAC_O) $(LUA_A) $(LIBS)
+
+test: $(LUA_T)
+	./$(LUA_T) -v
+
+clean:
+	$(RM) $(ALL_T) $(ALL_O)
+
+depend:
+	@$(CC) $(CFLAGS) -MM l*.c
+
+echo:
+	@echo "PLAT= $(PLAT)"
+	@echo "CC= $(CC)"
+	@echo "CFLAGS= $(CFLAGS)"
+	@echo "LDFLAGS= $(SYSLDFLAGS)"
+	@echo "LIBS= $(LIBS)"
+	@echo "AR= $(AR)"
+	@echo "RANLIB= $(RANLIB)"
+	@echo "RM= $(RM)"
+	@echo "UNAME= $(UNAME)"
+	@echo "LUA_BUILD_DIR= $(LUA_BUILD_DIR)"
+
+# Convenience targets for popular platforms.
+ALL= all
+
+help:
+	@echo "Do 'make PLATFORM' where PLATFORM is one of these:"
+	@echo "   $(PLATS)"
+	@echo "See doc/readme.html for complete instructions."
+
+guess:
+	@echo Guessing `$(UNAME)`
+	@$(MAKEF) LUA_BUILD_DIR=$(LUA_BUILD_DIR) `$(UNAME)`
+
+AIX aix:
+	$(MAKEF) $(ALL) LUA_BUILD_DIR=$(LUA_BUILD_DIR) CC="xlc" CFLAGS="-O2 -DLUA_USE_POSIX -DLUA_USE_DLOPEN" SYSLIBS="-ldl" SYSLDFLAGS="-brtl -bexpall"
+
+bsd:
+	$(MAKEF) $(ALL) LUA_BUILD_DIR=$(LUA_BUILD_DIR) SYSCFLAGS="-DLUA_USE_POSIX -DLUA_USE_DLOPEN" SYSLIBS="-Wl,-E"
+
+c89:
+	$(MAKEF) $(ALL) LUA_BUILD_DIR=$(LUA_BUILD_DIR) SYSCFLAGS="-DLUA_USE_C89" CC="gcc -std=c89"
+	@echo ''
+	@echo '*** C89 does not guarantee 64-bit integers for Lua.'
+	@echo '*** Make sure to compile all external Lua libraries'
+	@echo '*** with LUA_USE_C89 to ensure consistency'
+	@echo ''
+
+FreeBSD NetBSD OpenBSD freebsd:
+	$(MAKEF) $(ALL) LUA_BUILD_DIR=$(LUA_BUILD_DIR) SYSCFLAGS="-DLUA_USE_LINUX -DLUA_USE_READLINE -I/usr/include/edit" SYSLIBS="-Wl,-E -ledit" CC="cc"
+
+generic: $(ALL)
+
+Linux linux:	linux-noreadline
+
+linux-noreadline:
+	$(MAKEF) $(ALL) LUA_BUILD_DIR=$(LUA_BUILD_DIR) SYSCFLAGS="-DLUA_USE_LINUX -fPIC -fno-omit-frame-pointer" SYSLIBS="-Wl,-E -ldl"
+
+linux-readline:
+	$(MAKEF) $(ALL) LUA_BUILD_DIR=$(LUA_BUILD_DIR) SYSCFLAGS="-DLUA_USE_LINUX -DLUA_USE_READLINE" SYSLIBS="-Wl,-E -ldl -lreadline"
+
+Darwin macos macosx:
+	$(MAKEF) $(ALL) LUA_BUILD_DIR=$(LUA_BUILD_DIR) SYSCFLAGS="-DLUA_USE_MACOSX -DLUA_USE_READLINE" SYSLIBS="-lreadline"
+
+mingw:
+	$(MAKEF) "LUA_A=lua54.dll" "LUA_T=lua.exe" "LUA_BUILD_DIR=$(LUA_BUILD_DIR)" AR="$(CC) -shared -o" RANLIB="strip --strip-unneeded" SYSCFLAGS="-DLUA_BUILD_AS_DLL" SYSLIBS="" SYSLDFLAGS="-s" lua.exe
+	$(MAKEF) "LUAC_T=luac.exe" "LUA_BUILD_DIR=$(LUA_BUILD_DIR)" luac.exe
+
+posix:
+	$(MAKEF) $(ALL) LUA_BUILD_DIR=$(LUA_BUILD_DIR) SYSCFLAGS="-DLUA_USE_POSIX"
+
+SunOS solaris:
+	$(MAKEF) $(ALL) LUA_BUILD_DIR=$(LUA_BUILD_DIR) SYSCFLAGS="-DLUA_USE_POSIX -DLUA_USE_DLOPEN -D_REENTRANT" SYSLIBS="-ldl"
+
+# Compiler modules may use special flags.
+$(OBJ_DIR)/llex.o: llex.c
+	@mkdir -p $(OBJ_DIR)
+	$(CC) $(CFLAGS) $(CMCFLAGS) -c llex.c -o $(OBJ_DIR)/llex.o
+
+$(OBJ_DIR)/lparser.o: lparser.c
+	@mkdir -p $(OBJ_DIR)
+	$(CC) $(CFLAGS) $(CMCFLAGS) -c lparser.c -o $(OBJ_DIR)/lparser.o
+
+$(OBJ_DIR)/lcode.o: lcode.c
+	@mkdir -p $(OBJ_DIR)
+	$(CC) $(CFLAGS) $(CMCFLAGS) -c lcode.c -o $(OBJ_DIR)/lcode.o
+
+# DO NOT DELETE
+
+$(OBJ_DIR)/lapi.o: lapi.c lprefix.h lua.h luaconf.h lapi.h llimits.h lstate.h lobject.h ltm.h lzio.h lmem.h ldebug.h ldo.h lfunc.h lgc.h lstring.h ltable.h lundump.h lvm.h
+$(OBJ_DIR)/lauxlib.o: lauxlib.c lprefix.h lua.h luaconf.h lauxlib.h
+$(OBJ_DIR)/lbaselib.o: lbaselib.c lprefix.h lua.h luaconf.h lauxlib.h lualib.h
+$(OBJ_DIR)/lcode.o: lcode.c lprefix.h lua.h luaconf.h lcode.h llex.h lobject.h llimits.h lzio.h lmem.h lopcodes.h lparser.h ldebug.h lstate.h ltm.h ldo.h lgc.h lstring.h ltable.h lvm.h
+$(OBJ_DIR)/lcorolib.o: lcorolib.c lprefix.h lua.h luaconf.h lauxlib.h lualib.h
+$(OBJ_DIR)/lctype.o: lctype.c lprefix.h lctype.h lua.h luaconf.h llimits.h
+$(OBJ_DIR)/ldblib.o: ldblib.c lprefix.h lua.h luaconf.h lauxlib.h lualib.h
+$(OBJ_DIR)/ldebug.o: ldebug.c lprefix.h lua.h luaconf.h lapi.h llimits.h lstate.h lobject.h ltm.h lzio.h lmem.h lcode.h llex.h lopcodes.h lparser.h ldebug.h ldo.h lfunc.h lstring.h lgc.h ltable.h lvm.h
+$(OBJ_DIR)/ldo.o: ldo.c lprefix.h lua.h luaconf.h lapi.h llimits.h lstate.h lobject.h ltm.h lzio.h lmem.h ldebug.h ldo.h lfunc.h lgc.h lopcodes.h lparser.h lstring.h ltable.h lundump.h lvm.h
+$(OBJ_DIR)/ldump.o: ldump.c lprefix.h lua.h luaconf.h lobject.h llimits.h lstate.h ltm.h lzio.h lmem.h lundump.h
+$(OBJ_DIR)/lfunc.o: lfunc.c lprefix.h lua.h luaconf.h ldebug.h lstate.h lobject.h llimits.h ltm.h lzio.h lmem.h ldo.h lgc.h
+$(OBJ_DIR)/lgc.o: lgc.c lprefix.h lua.h luaconf.h ldebug.h lstate.h lobject.h llimits.h ltm.h lzio.h lmem.h ldo.h lfunc.h lgc.h lstring.h ltable.h
+$(OBJ_DIR)/linit.o: linit.c lprefix.h lua.h luaconf.h lualib.h lauxlib.h
+$(OBJ_DIR)/liolib.o: liolib.c lprefix.h lua.h luaconf.h lauxlib.h lualib.h
+$(OBJ_DIR)/llex.o: llex.c lprefix.h lua.h luaconf.h lctype.h llimits.h ldebug.h lstate.h lobject.h ltm.h lzio.h lmem.h ldo.h lgc.h llex.h lparser.h lstring.h ltable.h
+$(OBJ_DIR)/lmathlib.o: lmathlib.c lprefix.h lua.h luaconf.h lauxlib.h lualib.h
+$(OBJ_DIR)/lmem.o: lmem.c lprefix.h lua.h luaconf.h ldebug.h lstate.h lobject.h llimits.h ltm.h lzio.h lmem.h ldo.h lgc.h
+$(OBJ_DIR)/loadlib.o: loadlib.c lprefix.h lua.h luaconf.h lauxlib.h lualib.h
+$(OBJ_DIR)/lobject.o: lobject.c lprefix.h lua.h luaconf.h lctype.h llimits.h ldebug.h lstate.h lobject.h ltm.h lzio.h lmem.h ldo.h lstring.h lgc.h lvm.h
+$(OBJ_DIR)/lopcodes.o: lopcodes.c lprefix.h lopcodes.h llimits.h lua.h luaconf.h
+$(OBJ_DIR)/loslib.o: loslib.c lprefix.h lua.h luaconf.h lauxlib.h lualib.h
+$(OBJ_DIR)/lparser.o: lparser.c lprefix.h lua.h luaconf.h lcode.h llex.h lobject.h llimits.h lzio.h lmem.h lopcodes.h lparser.h ldebug.h lstate.h ltm.h ldo.h lfunc.h lstring.h lgc.h ltable.h
+$(OBJ_DIR)/lstate.o: lstate.c lprefix.h lua.h luaconf.h lapi.h llimits.h lstate.h lobject.h ltm.h lzio.h lmem.h ldebug.h ldo.h lfunc.h lgc.h llex.h lstring.h ltable.h
+$(OBJ_DIR)/lstring.o: lstring.c lprefix.h lua.h luaconf.h ldebug.h lstate.h lobject.h llimits.h ltm.h lzio.h lmem.h ldo.h lstring.h lgc.h
+$(OBJ_DIR)/lstrlib.o: lstrlib.c lprefix.h lua.h luaconf.h lauxlib.h lualib.h
+$(OBJ_DIR)/ltable.o: ltable.c lprefix.h lua.h luaconf.h ldebug.h lstate.h lobject.h llimits.h ltm.h lzio.h lmem.h ldo.h lgc.h lstring.h ltable.h lvm.h
+$(OBJ_DIR)/ltablib.o: ltablib.c lprefix.h lua.h luaconf.h lauxlib.h lualib.h
+$(OBJ_DIR)/ltm.o: ltm.c lprefix.h lua.h luaconf.h ldebug.h lstate.h lobject.h llimits.h ltm.h lzio.h lmem.h ldo.h lgc.h lstring.h ltable.h lvm.h
+$(OBJ_DIR)/lua.o: lua.c lprefix.h lua.h luaconf.h lauxlib.h lualib.h
+$(OBJ_DIR)/luac.o: luac.c lprefix.h lua.h luaconf.h lauxlib.h ldebug.h lstate.h lobject.h llimits.h ltm.h lzio.h lmem.h lopcodes.h lopnames.h lundump.h
+$(OBJ_DIR)/lundump.o: lundump.c lprefix.h lua.h luaconf.h ldebug.h lstate.h lobject.h llimits.h ltm.h lzio.h lmem.h ldo.h lfunc.h lstring.h lgc.h lundump.h
+$(OBJ_DIR)/lutf8lib.o: lutf8lib.c lprefix.h lua.h luaconf.h lauxlib.h lualib.h
+$(OBJ_DIR)/lvm.o: lvm.c lprefix.h lua.h luaconf.h ldebug.h lstate.h lobject.h llimits.h ltm.h lzio.h lmem.h ldo.h lfunc.h lgc.h lopcodes.h lstring.h ltable.h lvm.h ljumptab.h
+$(OBJ_DIR)/lzio.o: lzio.c lprefix.h lua.h luaconf.h llimits.h lmem.h lstate.h lobject.h ltm.h lzio.h
+
+# (end of Makefile)

--- a/src/extern/ceq/source/ceq_files_parallel.mk
+++ b/src/extern/ceq/source/ceq_files_parallel.mk
@@ -1,0 +1,16 @@
+# object and source files needed to build ceq
+# Note that we list just the D-language source files.
+#
+CEQ_DIR ?= .
+CEQ_BUILD_DIR ?= ./build
+
+CEQ_SRC_FILES := $(CEQ_DIR)/ceq.d
+
+CEQ_OBJ_FILES := $(CEQ_BUILD_DIR)/ceq.o \
+	$(CEQ_BUILD_DIR)/common.o \
+	$(CEQ_BUILD_DIR)/linalg.o \
+	$(CEQ_BUILD_DIR)/pt.o \
+	$(CEQ_BUILD_DIR)/rhou.o \
+	$(CEQ_BUILD_DIR)/ps.o \
+	$(CEQ_BUILD_DIR)/rhot.o \
+	$(CEQ_BUILD_DIR)/thermo.o

--- a/src/extern/ceq/source/parallel.make
+++ b/src/extern/ceq/source/parallel.make
@@ -1,0 +1,67 @@
+CEA_BUILD_DIR ?= ./build
+CC = gcc
+CFLAGS := -I. -fPIC -Wall -std=c99 -O3
+INSTALL_DIR ?= $(HOME)/ceq
+OBJS = $(CEA_BUILD_DIR)/thermo.o $(CEA_BUILD_DIR)/linalg.o $(CEA_BUILD_DIR)/common.o \
+       $(CEA_BUILD_DIR)/pt.o $(CEA_BUILD_DIR)/rhou.o $(CEA_BUILD_DIR)/ps.o \
+       $(CEA_BUILD_DIR)/rhot.o $(CEA_BUILD_DIR)/ceq.o
+
+all: $(CEA_BUILD_DIR)/libceq.so $(CEA_BUILD_DIR)/libceq.a
+
+$(CEA_BUILD_DIR)/libceq.so: $(OBJS)
+	$(CC) $(CFLAGS) -shared $^ -lm -o $@
+
+$(CEA_BUILD_DIR)/libceq.a: $(OBJS)
+	ar r $@ $^
+	ranlib $@
+
+$(CEA_BUILD_DIR)/thermo.o: thermo.c thermo.h
+	@mkdir -p $(@D)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(CEA_BUILD_DIR)/linalg.o: linalg.c linalg.h
+	@mkdir -p $(@D)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(CEA_BUILD_DIR)/common.o: common.c common.h
+	@mkdir -p $(@D)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(CEA_BUILD_DIR)/pt.o: pt.c thermo.h linalg.h common.h pt.h
+	@mkdir -p $(@D)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(CEA_BUILD_DIR)/rhou.o: rhou.c thermo.h linalg.h common.h rhou.h
+	@mkdir -p $(@D)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(CEA_BUILD_DIR)/ps.o: ps.c thermo.h linalg.h common.h ps.h
+	@mkdir -p $(@D)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(CEA_BUILD_DIR)/rhot.o: rhot.c thermo.h linalg.h common.h rhot.h
+	@mkdir -p $(@D)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(CEA_BUILD_DIR)/ceq.o: ceq.c thermo.h pt.h rhou.h ps.h rhot.h ceq.h
+	@mkdir -p $(@D)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+install: 
+	mkdir -p $(INSTALL_DIR)
+	cp $(CEA_BUILD_DIR)/libceq.so $(INSTALL_DIR)
+	sed -e "s+DBPATH='../thermo.inp'+DBPATH='$(INSTALL_DIR)/thermo.inp'+" \
+        -e "s+LIBPATH='./libceq.so'+LIBPATH='$(INSTALL_DIR)/libceq.so'+" \
+	    -e "s+HEADERFILE='./ceq.h'+HEADERFILE='$(INSTALL_DIR)/ceq.h'+" \
+        pyeq.py > $(INSTALL_DIR)/pyeq.py
+	cp clib.py $(INSTALL_DIR)
+	cp ../thermo.inp $(INSTALL_DIR)
+	cp ceq.h $(INSTALL_DIR)
+	cp -r ../tests $(INSTALL_DIR)/
+
+moduletests: $(CEA_BUILD_DIR)/thermo.o $(CEA_BUILD_DIR)/linalg.o
+	$(CC) thermo.c -D TEST -lm -o ../tests/testthermo
+	$(CC) linalg.c -D TEST -lm -o ../tests/testlinalg
+
+clean:
+	rm -rf $(CEA_BUILD_DIR)

--- a/src/lmr/force_tuple_instantiation.d
+++ b/src/lmr/force_tuple_instantiation.d
@@ -1,0 +1,10 @@
+module force_tuple_instantiation;
+
+import std.typecons;
+
+static this() {
+    // Force the instantiation of Tuple!(int, double).opEquals by invoking it.
+    Tuple!(int, double) a, b;
+    a.opEquals(b);
+}
+

--- a/src/lmr/lmr-files.mk
+++ b/src/lmr/lmr-files.mk
@@ -16,6 +16,7 @@ LMR_CORE_FILES = $(LMR)/block.d \
 	$(LMR)/fluidblockarray.d \
 	$(LMR)/fluxcalc.d \
 	$(LMR)/fluidfvcell.d \
+	$(LMR)/force_tuple_instantiation.d \
 	$(LMR)/fvcell.d \
 	$(LMR)/fvcellio.d \
 	$(LMR)/fvinterface.d \

--- a/src/lmr/main.d
+++ b/src/lmr/main.d
@@ -2,6 +2,7 @@ import std.algorithm;
 import std.getopt;
 import std.stdio;
 
+import force_tuple_instantiation;
 import lmr.commands.command;
 import lmr.commands.computenorms;
 import lmr.commands.customscript;

--- a/src/lmr/parallel.make
+++ b/src/lmr/parallel.make
@@ -1,0 +1,356 @@
+DMD ?= ldc2
+NVCC ?= nvcc
+GPP ?= g++
+OPT_OUT_MPI ?= 0
+MPI_IMPLEMENTATION := OpenMPI
+WITH_MPICH ?= 0
+
+FLAVOUR ?= debug
+WITH_FPE ?= 1
+
+ifeq ($(shell uname -s), Darwin)
+    PLATFORM := macosx
+else
+    PLATFORM := linux
+endif
+$(info PLATFORM=$(PLATFORM))
+
+WITH_OPENCL_GPU_CHEM ?= 0
+WITH_CUDA_GPU_CHEM ?= 0
+DEBUG_CHEM ?= 0
+WITH_DIAGNOSTICS ?= 0
+MULTI_SPECIES_GAS ?= 1
+MULTI_T_GAS ?= 1
+MHD ?= 1
+TURBULENCE ?= 1
+WITH_E4DEBUG ?= 0
+WITH_CHECK_JAC ?= 0
+
+WITH_THREAD_SANITIZER ?= 0
+WITH_ADDRESS_SANITIZER ?= 0
+
+OPENMPI_DIR := ../extern/OpenMPI
+OPENMPI_FILES := $(OPENMPI_DIR)/source/mpi/package.d
+MPI_DIR = $(OPENMPI_DIR)
+MPI_FILES = $(OPENMPI_FILES)
+MPICH_DIR := ../extern/cray-mpich
+MPICH_FILES := $(MPICH_DIR)/mpi.d
+
+PROGRAMS := lmr lmr-debug gdtk-module
+SUB_PROGRAMS := lmr-run lmrZ-run
+ifeq ($(OPT_OUT_MPI), 0)
+	SUB_PROGRAMS += lmr-mpi-run lmrZ-mpi-run
+endif
+ifeq ($(WITH_MPICH),1)
+    MPI_LIBRARY_DIRS = $(shell mpicc -link_info | cut -d' ' -f 3)
+    MPI_LIB_DIRS_SEARCH = $(foreach d, $(MPI_LIBRARY_DIRS), -L$$d)
+    MPI_DIR = $(MPICH_DIR)
+    MPI_FILES = $(MPICH_FILES)
+	MPI_IMPLEMENTATION := MPICH
+endif
+ifeq ($(WITH_CHECK_JAC), 1)
+	SUB_PROGRAMS += lmr-check-jacobian lmrZ-check-jacobian
+endif
+
+include lmr-files.mk
+
+UTIL_DIR := ../util
+include $(UTIL_DIR)/util_files.mk
+
+NM_DIR := ../nm
+include $(NM_DIR)/nm_files.mk
+
+NML_DIR := ../lib
+include $(NML_DIR)/nml_files.mk
+
+GAS_DIR := ../gas
+GAS_PACKAGE := gas
+include $(GAS_DIR)/gas_files.mk
+
+GRID_DIR := ../grid_utils
+include $(GRID_DIR)/grid_utils_files.mk
+
+KINETICS_DIR := ../kinetics
+include $(KINETICS_DIR)/kinetics_files.mk
+
+GEOM_DIR := ../geom
+include $(GEOM_DIR)/geom_files.mk
+
+GASDYN_DIR := ../gasdyn
+include $(GASDYN_DIR)/gasdyn_files.mk
+
+NTYPES_DIR := ../ntypes
+NTYPES_FILES := $(NTYPES_DIR)/complex.d
+
+GZIP_DIR := ../extern/gzip
+GZIP_FILES := $(GZIP_DIR)/gzip.d
+
+DYAML_DIR := ../extern/D-YAML/source/dyaml
+include $(DYAML_DIR)/dyaml_files.mk
+
+TINYENDIAN_DIR := ../extern/tinyendian/source
+include $(TINYENDIAN_DIR)/tinyendian_files.mk
+
+MPL_DIR := ../extern/matplotlib.d/source
+MPL_FILES := $(MPL_DIR)/matplotlibd/pyplot.d \
+	$(MPL_DIR)/matplotlibd/core/pycall.d \
+	$(MPL_DIR)/matplotlibd/core/translate.d
+
+GPERF_DIR := ../extern/gperftools_d/source/gperftools_d
+GPERF_FILES := $(GPERF_DIR)/heap_profiler.d \
+	$(GPERF_DIR)/malloc_extension_c.d \
+	$(GPERF_DIR)/malloc_hook_c.d \
+	$(GPERF_DIR)/profiler.d \
+	$(GPERF_DIR)/stacktrace.d \
+	$(GPERF_DIR)/tcmalloc.d \
+
+DFLAGS += -I.. -I$(NM_DIR) -I$(UTIL_DIR) -I$(GEOM_DIR) -I$(GRID_DIR) -I$(GZIP_DIR) -I$(CEQ_DIR) -I$(DYAML_DIR)/.. -I$(TINYENDIAN_DIR)
+
+INSTALL_DIR ?= $(HOME)/gdtkinst
+BUILD_DIR := $(abspath ../../build)
+OBJ_DIR := $(abspath $(BUILD_DIR)/obj)
+BUILD_DATE := $(shell date)
+REVISION_STRING := $(shell git rev-parse --short HEAD)
+FULL_REVISION_STRING := $(shell git rev-parse HEAD)
+REVISION_AGE := $(shell git log -1 --format=%cd --date=relative)
+REVISION_DATE := $(shell git log -1 --format=%cd)
+REPO_DIR := $(shell cd ../../; pwd)
+
+CEQ_DIR := ../extern/ceq/source
+CEQ_BUILD_DIR := $(abspath $(OBJ_DIR)/extern/ceq/source)
+LIBCEQ := $(CEQ_BUILD_DIR)/libceq.a
+include $(CEQ_DIR)/ceq_files_parallel.mk
+
+LUA_DIR := $(abspath ../../extern/lua-5.4.3/src)
+LUA_BUILD_DIR := $(abspath $(BUILD_DIR)/extern/lua)
+LIBLUA := $(LUA_BUILD_DIR)/liblua.a
+LIBLUAPATH := $(LUA_BUILD_DIR)
+
+ifeq ($(DMD), ldc2)
+    DEBUG_DFLAGS := -w -g --d-debug --d-version=flavour_debug
+    PROFILE_DFLAGS := -fprofile-generate -g -w -O2 -release -enable-inlining -boundscheck=off --d-version=flavour_profile
+    ifeq ($(PLATFORM), macosx)
+        FAST_DFLAGS := -w -g -O1 -release -enable-inlining -boundscheck=off --d-version=flavour_fast
+    else
+        FAST_DFLAGS := -w -g -O2 -release -enable-inlining -boundscheck=off --d-version=flavour_fast
+    endif
+    ifeq ($(PLATFORM), linux)
+        FAST_DFLAGS += -flto=full
+    endif
+    ifeq ($(WITH_THREAD_SANITIZER), 1)
+        DFLAGS := $(DFLAGS) -fsanitize=thread
+    endif
+    ifeq ($(WITH_ADDRESS_SANITIZER), 1)
+        DFLAGS := $(DFLAGS) -fsanitize=address
+    endif
+    OF := -of=
+    DVERSION := -d-version=
+
+    # pass LINKER_FLAGS="--linker=mold" for fast linking
+    DLINKFLAGS := $(LINKER_FLAGS)
+    ifeq ($(WITH_THREAD_SANITIZER), 1)
+        DLINKFLAGS := $(DLINKFLAGS) -fsanitize=thread
+    endif
+    ifeq ($(WITH_ADDRESS_SANITIZER), 1)
+        DLINKFLAGS := $(DLINKFLAGS) -fsanitize=address
+    endif
+    DLINKFLAGS := $(DLINKFLAGS) -L-ldl
+    ifeq ($(PLATFORM), linux)
+		DLINKFLAGS += -L-Wl,-E
+	endif
+    ifeq ($(PLATFORM), macosx)
+		DLINKFLAGS += -L-ld_classic
+    endif
+endif
+
+ifeq ($(FLAVOUR), debug)
+    FLAVOUR_FLAGS := $(DEBUG_DFLAGS)
+endif
+ifeq ($(FLAVOUR), profile)
+    FLAVOUR_FLAGS := $(PROFILE_DFLAGS)
+endif
+ifeq ($(FLAVOUR), fast)
+    FLAVOUR_FLAGS := $(FAST_DFLAGS)
+    WITH_FPE ?= 0
+endif
+
+ifeq ($(PLATFORM), macosx)
+	DFLAGS += $(DVERSION)macosx
+endif
+
+DFLAGS += -dip1008 -I.. -I$(NM_DIR) -I$(UTIL_DIR) -I$(GEOM_DIR) -I$(GRID_DIR) -I$(GZIP_DIR)
+ifeq ($(DEBUG_CHEM),1)
+    DFLAGS += $(DVERSION)debug_chem
+endif
+ifeq ($(WITH_FPE),1)
+    DFLAGS += $(DVERSION)enable_fp_exceptions
+endif
+ifeq ($(MULTI_SPECIES_GAS),1)
+    DFLAGS += $(DVERSION)multi_species_gas
+endif
+ifeq ($(MULTI_T_GAS),1)
+    DFLAGS += $(DVERSION)multi_T_gas
+endif
+ifeq ($(MHD),1)
+    DFLAGS += $(DVERSION)MHD
+endif
+ifeq ($(TURBULENCE),1)
+    DFLAGS += $(DVERSION)turbulence
+endif
+
+DFLAGS += $(DVERSION)newton_krylov
+
+SRC_DIR = $(abspath ../)
+CONFIG_BUILD_DIR = $(BUILD_DIR)/config
+
+LMR_SRCS = $(abspath main.d $(LMR_CORE_FILES) $(LMR_CMD_FILES) $(LMR_LUA_FILES) \
+           $(LMR_BC_FILES) $(LMR_SOLID_FILES) $(LMR_EFIELD_FILES) \
+           $(GEOM_FILES) $(GRID_FILES) \
+           $(GAS_FILES) $(CEQ_SRC_FILES) $(GZIP_FILES) \
+           $(UTIL_FILES) $(NM_FILES) $(NTYPES_FILES) \
+           $(KINETICS_FILES) $(GAS_LUA_FILES) $(KINETICS_LUA_FILES) \
+           $(GASDYN_FILES) $(GASDYN_LUA_FILES) $(NM_LUA_FILES) \
+           $(DYAML_FILES) $(TINYENDIAN_FILES))
+
+LMR_OBJS = $(patsubst $(SRC_DIR)/%.d,$(OBJ_DIR)/%.o,$(LMR_SRCS))
+
+$(LMR_OBJS): $(OBJ_DIR)/%.o: $(SRC_DIR)/%.d | $(LIBLUA) $(LIBCEQ)
+	@mkdir -p $(dir $@)
+	$(DMD) $(FLAVOUR_FLAGS) $(DFLAGS) -c -of=$@ $<
+
+$(CONFIG_BUILD_DIR)/lmrconfig_with_str_subst.d: lmrconfig.d
+	@mkdir -p $(dir $@)
+	sed -e 's/PUT_REVISION_STRING_HERE/$(REVISION_STRING)/' \
+	    -e 's/PUT_FULL_REVISION_STRING_HERE/$(FULL_REVISION_STRING)/' \
+	    -e 's/PUT_REVISION_DATE_HERE/$(REVISION_DATE)/' \
+	    -e 's/PUT_COMPILER_NAME_HERE/$(DMD)/' \
+	    -e 's/PUT_BUILD_DATE_HERE/$(BUILD_DATE)/' \
+	    $< > $@
+
+$(CONFIG_BUILD_DIR)/lmrconfig_with_str_subst.o: $(CONFIG_BUILD_DIR)/lmrconfig_with_str_subst.d
+	@mkdir -p $(dir $@)
+	$(DMD) $(FLAVOUR_FLAGS) $(DFLAGS) -c -of=$@ $<
+
+# $(CONFIG_BUILD_DIR)/runsim_shared_run.d: $(LMR_CMD)/runsim.d $(CONFIG_BUILD_DIR)/lmrconfig_with_str_subst.d
+# 	@mkdir -p $(dir $@)
+# 	sed -e 's/PUT_PARALLEL_FLAVOUR_HERE/shared/' \
+# 	    -e 's/PUT_NUMBER_TYPE_HERE/real/' \
+# 	    $< > $@
+# 
+# $(CONFIG_BUILD_DIR)/runsim_shared_z.d: $(LMR_CMD)/runsim.d $(CONFIG_BUILD_DIR)/lmrconfig_with_str_subst.d
+# 	@mkdir -p $(dir $@)
+# 	sed -e 's/PUT_PARALLEL_FLAVOUR_HERE/shared/' \
+# 	    -e 's/PUT_NUMBER_TYPE_HERE/complex/' \
+# 	    $< > $@
+# 
+# $(CONFIG_BUILD_DIR)/runsim_mpi_run.d: $(LMR_CMD)/runsim.d $(CONFIG_BUILD_DIR)/lmrconfig_with_str_subst.d
+# 	@mkdir -p $(dir $@)
+# 	sed -e 's/PUT_PARALLEL_FLAVOUR_HERE/$(MPI_IMPLEMENTATION)/' \
+# 	    -e 's/PUT_NUMBER_TYPE_HERE/real/' \
+# 	    $< > $@
+# 
+# $(CONFIG_BUILD_DIR)/runsim_mpi_z.d: $(LMR_CMD)/runsim.d $(CONFIG_BUILD_DIR)/lmrconfig_with_str_subst.d
+# 	@mkdir -p $(dir $@)
+# 	sed -e 's/PUT_PARALLEL_FLAVOUR_HERE/$(MPI_IMPLEMENTATION)/' \
+# 	    -e 's/PUT_NUMBER_TYPE_HERE/complex/' \
+# 	    $< > $@
+
+
+.PHONY: lmr
+lmr: $(BUILD_DIR)/lmr
+
+$(BUILD_DIR)/lmr: $(LMR_OBJS) $(LIBCEQ) $(LIBLUA) $(CONFIG_BUILD_DIR)/lmrconfig_with_str_subst.o
+	$(DMD) $(FLAVOUR_FLAGS) $(DFLAGS) -of=$@ $(LMR_OBJS) $(CONFIG_BUILD_DIR)/lmrconfig_with_str_subst $(LIBCEQ) $(LIBLUA) $(DLINKFLAGS)
+
+lmr-debug: $(LMR_OBJS) $(LIBCEQ) $(LIBLUA)
+	$(DMD) $(DEBUG_DFLAGS) $(DFLAGS) -of=$@ $(LMR_OBJS) $(LIBCEQ) $(LIBLUA) $(DLINKFLAGS)
+
+LMR_RUN_SRCS = runsim_shared_run.d $(LMR_CORE_FILES) $(LMR_CMD_FILES) $(LMR_LUA_FILES) \
+               $(LMR_BC_FILES) $(LMR_SOLID_FILES) $(LMR_EFIELD_FILES) \
+               $(GEOM_FILES) $(GRID_FILES) \
+               $(GAS_FILES) $(CEQ_SRC_FILES) $(GZIP_FILES) \
+               $(UTIL_FILES) $(NM_FILES) $(NTYPES_FILES) \
+               $(KINETICS_FILES) $(GAS_LUA_FILES) $(KINETICS_LUA_FILES) \
+               $(GASDYN_FILES) $(GASDYN_LUA_FILES) $(NM_LUA_FILES) \
+               $(DYAML_FILES) $(TINYENDIAN_FILES)
+LMR_RUN_OBJS = $(patsubst %.d,$(OBJ_DIR)/%.o,$(LMR_RUN_SRCS))
+
+lmr-run: runsim_shared_run.d $(LMR_RUN_OBJS) $(LIBCEQ) $(LIBLUA)
+	$(DMD) $(FLAVOUR_FLAGS) $(DFLAGS) -of=$@ -Drun_main $(LMR_RUN_OBJS) $(LIBCEQ) $(LIBLUA) $(DLINKFLAGS)
+
+
+$(LIBLUA):
+	$(MAKE) LUA_BUILD_DIR=$(LUA_BUILD_DIR) -C $(LUA_DIR) -f parallel.make PLATFORM=$(PLATFORM)
+	$(MAKE) LP_BUILD_DIR=$(LUA_BUILD_DIR) -C $(LUA_DIR)/../lpeg-1.0.2 -f parallel.make $(PLATFORM)
+
+$(LIBCEQ):
+	$(MAKE) CEA_BUILD_DIR=$(CEQ_BUILD_DIR) -C $(CEQ_DIR) -f parallel.make
+
+$(LIBGASF):
+	cd $(GAS_DIR); make BUILD_DIR=$(BUILD_DIR) DMD=$(DMD) libgasf.a
+
+lmr-verify: $(PY_PROG_DIR)/lmr_verify.py
+	cp $< $@
+	chmod +x $@
+
+prep-gas:
+	cd $(GAS_DIR); make BUILD_DIR=$(BUILD_DIR) DMD=$(DMD) PLATFORM=$(PLATFORM) build-prep-gas
+
+ugrid_partition:
+	- mkdir -p $(BUILD_DIR)/bin
+	cd $(GRID_DIR); make BUILD_DIR=$(BUILD_DIR) DMD=$(DMD) PLATFORM=$(PLATFORM) ugrid_partition
+	cd $(GRID_DIR); cp ugrid_partition $(BUILD_DIR)/bin
+
+prep-chem:
+	cd $(KINETICS_DIR); make BUILD_DIR=$(BUILD_DIR) DMD=$(DMD) PLATFORM=$(PLATFORM) build-prep-chem
+
+chemkin2eilmer:
+	cd $(KINETICS_DIR); make BUILD_DIR=$(BUILD_DIR) DMD=$(DMD) PLATFORM=$(PLATFORM) build-chemkin2eilmer
+
+prep-kinetics:
+	cd $(KINETICS_DIR); make BUILD_DIR=$(BUILD_DIR) DMD=$(DMD) PLATFORM=$(PLATFORM) build-prep-kinetics
+
+gdtk-module:
+	sed -e 's+PUT_REVISION_STRING_HERE+$(REVISION_STRING)+' \
+	    -e 's+PUT_COMPILER_NAME_HERE+$(DMD)+' \
+	    -e 's+PUT_INSTALL_DIR_HERE+$(INSTALL_DIR)+' \
+	    -e 's+PUT_REPO_DIR_HERE+$(REPO_DIR)+' \
+	    -e 's+PUT_BUILD_DATE_HERE+$(BUILD_DATE)+' \
+	    -e 's+PUT_REVISION_AGE_HERE+$(REVISION_AGE)+' \
+	    -e 's+PUT_REPO_DIR_HERE+$(REPO_DIR)+' \
+	    ../eilmer/gdtk-module-template > gdtk-module
+
+.PHONY: default install clean prep-gas ugrid_partition prep-chem chemkin2eilmer prep-kinetics gdtk-module
+
+default: $(PROGRAMS) $(SUB_PROGRAMS)
+
+# TODO: FIXME
+install: $(PROGRAMS) $(SUB_PROGRAMS) $(PY_PROGRAMS) $(AUX_PROGRAMS)
+	- mkdir -p $(INSTALL_DIR)/bin $(INSTALL_DIR)/lib $(INSTALL_DIR)/etc $(INSTALL_DIR)/share
+	cp $(PROGRAMS) $(INSTALL_DIR)/bin
+	cp $(SUB_PROGRAMS) $(INSTALL_DIR)/bin
+	cp $(PY_PROGRAMS) $(INSTALL_DIR)/bin
+	cp lua-modules/*.lua $(INSTALL_DIR)/lib/
+	cp lmr.cfg $(INSTALL_DIR)/etc/
+	cp $(LUA_DIR)/install/bin/* $(BUILD_DIR)/bin
+	cp $(LUA_DIR)/install/lib/lpeg.so $(BUILD_DIR)/lib
+	cp -r ../lib/* $(BUILD_DIR)/lib
+	cp $(NML_LUA_MODULES) $(BUILD_DIR)/lib
+	cp gdtk-module $(INSTALL_DIR)/share
+	cp share/* $(INSTALL_DIR)/share
+	cp -r $(BUILD_DIR)/* $(INSTALL_DIR)
+
+clean:
+	- rm -f $(OBJ_DIR)/*.o
+	- rm -rf $(BUILD_DIR)/*
+	- rm -f $(PROGRAMS) $(SUB_PROGRAMS) $(PY_PROGRAMS)
+	- rm -f lmrconfig_with_str_subst.d runsim_shared_run.d runsim_shared_z.d runsim_mpi_run.d runsim_mpi_z.d
+	- cd $(OPENMPI_DIR); make clean
+	- cd $(MPICH_DIR); make clean
+	- cd $(LUA_DIR); make clean
+	- cd $(GEOM_DIR); make clean
+	- cd $(GZIP_DIR); make clean
+	- cd $(GAS_DIR); make clean; rm -f libgas.a
+	- cd $(KINETICS_DIR); make clean
+	- cd $(GRID_DIR); make clean
+	- cd $(CEQ_DIR); make clean


### PR DESCRIPTION
Just putting this up so people can test. It needs a little bit of work adding the remaining targets and fixing the `install` target. Filenames `parallel.make` are temporary and some of the `abspath` stuff is not super robust, but I got too excited and forged ahead.

Currently only works for the `lmr` target.

```sh
make LINKER_FLAGS="--linker=mold" -f parallel.make -j(nproc)
```

The command above will put the `lmr` binary (as well as all other object files, libraries and archives) in `BUILD_DIR`, which is `../../build` by default. Leave out the `LINKER_FLAGS` line if you don't have `mold` installed but if you do, it speeds up linking by at least an order of magnitude. Try changing a file and re-compiling with the same command. It should be really fast.

Disclaimer: I haven't tested with any actual sims yet. I compiled it and checked that it doesn't immediately crash when calling `lmr` and various sub-commands (as long as the necessary config files are in your home directory from a previous installation).

`force_tuple_instantiation.d` is there to stop the linker from complaining.

Please test this properly for me, I'm not an eilmer user,  I just enjoy the colours when all the bars in `htop` are maxed out.