### PR TITLE
Prefix module names for D programs outside of `lmr`

### DIFF
--- a/src/l1d/config.d
+++ b/src/l1d/config.d
@@ -1,10 +1,11 @@
 // config.d
 // A place to keep the configuration details.
 
-module config;
+module l1d.config;
 
 import std.conv;
 import std.format;
+
 import nm.schedule;
 
 

--- a/src/l1d/endcondition.d
+++ b/src/l1d/endcondition.d
@@ -2,8 +2,7 @@
 // PA Jacobs
 // 2020-04-08
 //
-module endcondition;
-
+module l1d.endcondition;
 
 import std.conv;
 import std.stdio;
@@ -14,19 +13,20 @@ import std.format;
 import std.algorithm;
 import std.math;
 
-import util.json_helper;
-import geom;
+import l1d.config;
+import l1d.gasslug;
+import l1d.lcell;
+import l1d.misc;
+import l1d.piston;
+import l1d.simcore;
+import l1d.tube;
+
 import gas;
 import gasdyn.gasflow;
-import config;
-import tube;
-import gasslug;
-import lcell;
-import piston;
-import simcore;
-import misc;
+import geom;
+import util.json_helper;
 
-enum End { L, R };
+enum End { L, R }
 
 class EndCondition {
 public:

--- a/src/l1d/gasslug.d
+++ b/src/l1d/gasslug.d
@@ -5,7 +5,7 @@
 // PA Jacobs
 // 2020-04-08
 //
-module gasslug;
+module l1d.gasslug;
 
 import std.conv;
 import std.stdio;
@@ -16,18 +16,19 @@ import std.range;
 import std.math;
 import std.algorithm;
 
-import util.json_helper;
-import geom;
+import l1d.config;
+import l1d.endcondition;
+import l1d.lcell;
+import l1d.misc;
+import l1d.piston;
+import l1d.simcore; // has the core data arrays
+import l1d.valve;
+
 import gas;
-import kinetics;
 import gasdyn.gasflow;
-import config;
-import lcell;
-import piston;
-import valve;
-import endcondition;
-import simcore; // has the core data arrays
-import misc;
+import geom;
+import kinetics;
+import util.json_helper;
 
 class GasSlug {
 public:
@@ -514,7 +515,7 @@ public:
         // gas slugs running through a partially-closed valve.
         // Once a valve is fully open, this restriction no longer matters.
         //
-        foreach (valve; simcore.valves) {
+        foreach (valve; l1d.simcore.valves) {
             // Note that we need the current value of time
             // in order to evaluate fopen for the valve.
             double fopen = valve.fopen(t);

--- a/src/l1d/lcell.d
+++ b/src/l1d/lcell.d
@@ -6,18 +6,19 @@
 // PA Jacobs
 // 2020-04-09
 //
-module lcell;
+module l1d.lcell;
 
 import std.stdio;
 import std.math;
 import std.format;
 import std.algorithm;
 
-import geom;
+import l1d.config;
+
 import gas;
-import kinetics;
 import gasdyn.gasflow;
-import config;
+import geom;
+import kinetics;
 
 
 class LFace {

--- a/src/l1d/main.d
+++ b/src/l1d/main.d
@@ -16,9 +16,9 @@ import std.conv;
 import std.math;
 import std.parallelism: totalCPUs;
 
-import config;
-import simcore;
-import postprocess;
+import l1d.config;
+import l1d.postprocess;
+import l1d.simcore;
 
 int main(string[] args)
 {

--- a/src/l1d/misc.d
+++ b/src/l1d/misc.d
@@ -3,7 +3,7 @@
 //
 // PAJ, 2020-04-09
 //
-module misc;
+module l1d.misc;
 
 import std.conv;
 import std.stdio;
@@ -11,7 +11,7 @@ import std.string;
 import std.format;
 import std.algorithm;
 
-import config;
+import l1d.config;
 
 void skip_to_data_at_tindx(File fp, int tindx=0)
 {

--- a/src/l1d/piston.d
+++ b/src/l1d/piston.d
@@ -3,7 +3,7 @@
 // 2020-04-08
 // 2025-03-19 : allow variable piston mass.
 //
-module piston;
+module l1d.piston;
 
 import std.conv;
 import std.stdio;
@@ -14,14 +14,15 @@ import std.format;
 import std.algorithm;
 import std.math;
 
-import util.json_helper;
-import geom;
+import l1d.config;
+import l1d.endcondition;
+import l1d.lcell;
+import l1d.misc;
+
 import gas;
 import gasdyn.gasflow;
-import config;
-import endcondition;
-import lcell;
-import misc;
+import geom;
+import util.json_helper;
 
 
 class Piston {

--- a/src/l1d/postprocess.d
+++ b/src/l1d/postprocess.d
@@ -3,7 +3,7 @@
 // 2020-04-08
 // 2022-12-08 Add cell history for David Mee.
 //
-module postprocess;
+module l1d.postprocess;
 
 import std.conv;
 import std.stdio;
@@ -15,15 +15,16 @@ import std.algorithm;
 import std.math;
 import core.stdc.math: HUGE_VAL;
 
+import l1d.config;
+import l1d.gasslug;
+import l1d.lcell;
+import l1d.misc;
+import l1d.piston;
+import l1d.simcore;
+import l1d.tube;
+
 import util.json_helper;
 import gas;
-import config;
-import tube;
-import gasslug;
-import lcell;
-import piston;
-import simcore;
-import misc;
 
 
 void generate_cell_history(double x0, int tindxStart, int tindxEnd, bool milliSec)

--- a/src/l1d/simcore.d
+++ b/src/l1d/simcore.d
@@ -2,7 +2,7 @@
 // PA Jacobs
 // 2020-04-08
 //
-module simcore;
+module l1d.simcore;
 
 import std.conv;
 import std.stdio;
@@ -14,20 +14,21 @@ import std.algorithm;
 import std.range;
 import std.parallelism : parallel, defaultPoolThreads;
 
+import l1d.config;
+import l1d.endcondition;
+import l1d.gasslug;
+import l1d.lcell;
+import l1d.misc;
+import l1d.piston;
+import l1d.tube;
+import l1d.valve;
+
 import nm.schedule;
 import util.json_helper;
 import geom;
 import gas;
 import kinetics;
 import gasdyn.gasflow;
-import config;
-import tube;
-import gasslug;
-import lcell;
-import piston;
-import valve;
-import endcondition;
-import misc;
 
 __gshared static GasModel[] gmodels;
 __gshared static uint overall_species_count;

--- a/src/l1d/tube.d
+++ b/src/l1d/tube.d
@@ -3,7 +3,7 @@
 // 2020-04-08 Static tube definition.
 // 2021-04-16 Matt McGilvray's heat-transfer-augmentation factor.
 //
-module tube;
+module l1d.tube;
 
 import std.stdio;
 import std.string;
@@ -12,8 +12,9 @@ import std.conv;
 import std.math;
 import std.algorithm;
 
+import l1d.config;
+
 import geom;
-import config;
 
 class Tube {
 public:

--- a/src/l1d/valve.d
+++ b/src/l1d/valve.d
@@ -3,7 +3,7 @@
 // PA Jacobs
 // 2020-08-14
 
-module valve;
+module l1d.valve;
 
 import std.conv;
 import std.stdio;
@@ -12,9 +12,10 @@ import std.string;
 import std.json;
 import std.format;
 
+import l1d.config;
+
 import nm.schedule;
 import util.json_helper;
-import config;
 
 class Valve {
 public:

--- a/src/nenzf1d/configuration.d
+++ b/src/nenzf1d/configuration.d
@@ -5,11 +5,12 @@
 //
 // Authors: Nick Gibbons, Peter J., Rowan Gollan
 
-module configuration;
+module nenzf1d.configuration;
 
+import std.conv;
 import std.stdio;
 import std.string;
-import std.conv;
+
 import dyaml;
 
 

--- a/src/nenzf1d/cwrap.d
+++ b/src/nenzf1d/cwrap.d
@@ -9,11 +9,12 @@ Notes:
 
 import core.runtime;
 import core.stdc.string;
-import std.string;
-import std.stdio;
 import std.conv;
-import configuration;
-import shock_tube_nozzle;
+import std.stdio;
+import std.string;
+
+import nenzf1d.configuration;
+import nenzf1d.shock_tube_nozzle;
 
 Config config;
 Result result;
@@ -165,7 +166,7 @@ extern (C) PlainResult run(int verbosityLevel, PlainConfig cfg)
 
     PlainResult rst;
     try{
-        result = shock_tube_nozzle.analyse(verbosityLevel, config);
+        result = nenzf1d.shock_tube_nozzle.analyse(verbosityLevel, config);
         rst = d_result_to_c(result);
     }
     catch(Exception e) {

--- a/src/nenzf1d/main.d
+++ b/src/nenzf1d/main.d
@@ -1,16 +1,16 @@
 // main.d: Top level function for directly called nenzf1d,
 // a quasi-one-dimensional calculator for shock tunnel conditions.
 
-module nenzf1d;
-
+import std.file;
+import std.getopt;
+import std.math;
 import std.stdio;
 import std.string;
-import std.getopt;
-import std.file;
-import std.math;
+
 import dyaml;
-import configuration;
-import shock_tube_nozzle;
+
+import nenzf1d.configuration;
+import nenzf1d.shock_tube_nozzle;
 
 int main(string[] args)
 {

--- a/src/nenzf1d/shock_tube_nozzle.d
+++ b/src/nenzf1d/shock_tube_nozzle.d
@@ -2,26 +2,29 @@
 //
 // Authors: Peter J., Nick Gibbons, Rowan Gollan.
 //
-module shock_tube_nozzle;
+module nenzf1d.shock_tube_nozzle;
 
-import std.stdio;
 import std.array;
-import std.string;
 import std.conv;
-import std.getopt;
 import std.file;
+import std.getopt;
 import std.math;
+import std.stdio;
+import std.string;
+
 import dyaml;
-import nm.secant;
-import nm.schedule;
-import gas;
+
+import nenzf1d.configuration;
+
 import gas.cea_gas;
-import gas.therm_perf_gas;
 import gas.equilibrium_gas;
+import gas.therm_perf_gas;
 import gas.therm_perf_gas_equil;
-import kinetics;
+import gas;
 import gasdyn.gasflow;
-import configuration;
+import kinetics;
+import nm.schedule;
+import nm.secant;
 
 // Storage for the calculated gas state at the end of the facility nozzle.
 struct Result{

--- a/src/puffin/cell.d
+++ b/src/puffin/cell.d
@@ -3,22 +3,23 @@
 // PA Jacobs
 // 2022-01-22
 //
-module cell;
+module puffin.cell;
 
+import std.algorithm;
+import std.array;
+import std.conv;
 import std.format;
 import std.math;
-import std.algorithm;
-import std.conv;
-import std.array;
 
-import geom;
+import puffin.config;
+import puffin.face;
+import puffin.flow;
+import puffin.flux;
+
 import gas;
-import kinetics;
 import gasdyn.gasflow;
-import config;
-import flow;
-import face;
-import flux;
+import geom;
+import kinetics;
 
 
 class Cell2D {

--- a/src/puffin/config.d
+++ b/src/puffin/config.d
@@ -4,15 +4,15 @@
 // PA Jacobs
 // 2022-01-21
 //
-module config;
+module puffin.config;
 
 import std.conv;
-import std.stdio;
 import std.format;
 import std.json;
+import std.stdio;
 
-import util.json_helper;
 import nm.schedule;
+import util.json_helper;
 
 
 // To choose a flux calculator.

--- a/src/puffin/face.d
+++ b/src/puffin/face.d
@@ -3,17 +3,18 @@
 // PA Jacobs
 // 2022-01-22
 //
-module face;
+module puffin.face;
 
 import std.format;
 import std.math;
 
-import geom;
+import puffin.cell;
+import puffin.config;
+import puffin.flow;
+
 import gas;
 import gasdyn.gasflow;
-import config;
-import flow;
-import cell;
+import geom;
 
 
 class Face2D {

--- a/src/puffin/flow.d
+++ b/src/puffin/flow.d
@@ -3,12 +3,12 @@
 // PA Jacobs
 // 2022-01-22
 //
-module flow;
+module puffin.flow;
 
 import std.format;
 
-import geom;
 import gas;
+import geom;
 
 
 struct FlowState2D {

--- a/src/puffin/fluidblock.d
+++ b/src/puffin/fluidblock.d
@@ -3,30 +3,32 @@
 // PA Jacobs
 // 2022-12-12: Adapt from the Puffin and Chicken codes.
 //
-module fluidblock;
+module puffin.fluidblock;
 
+import core.stdc.math: HUGE_VAL;
+import std.algorithm;
 import std.conv;
+import std.file;
+import std.format;
+import std.json;
+import std.math;
+import std.range;
 import std.stdio;
 import std.string;
-import std.file;
-import std.json;
-import std.format;
-import std.range;
-import std.math;
-import std.algorithm;
-import core.stdc.math: HUGE_VAL;
+
 import gzip;
 
+import puffin.cell;
+import puffin.config;
+import puffin.face;
+import puffin.flow;
+import puffin.flux;
+
+import gas;
+import geom;
+import kinetics;
 import nm.schedule;
 import util.json_helper;
-import geom;
-import gas;
-import kinetics;
-import config;
-import flow;
-import cell;
-import face;
-import flux;
 
 enum BCCode {wall_with_slip=0, exchange=1, inflow=2, outflow=3};
 string[] BCCodeNames = ["wall_with_slip", "exchange", "inflow", "outflow"];

--- a/src/puffin/flux.d
+++ b/src/puffin/flux.d
@@ -3,19 +3,20 @@
 // PA Jacobs
 // 2022-02-02
 //
-module flux;
+module puffin.flux;
 
 import std.format;
 import std.math;
 
-import geom;
+import puffin.cell;
+import puffin.config;
+import puffin.face;
+import puffin.flow;
+import puffin.interp;
+
 import gas;
 import gasdyn.gasflow;
-import config;
-import flow;
-import face;
-import cell;
-import interp;
+import geom;
 
 
 @nogc

--- a/src/puffin/interp.d
+++ b/src/puffin/interp.d
@@ -3,18 +3,19 @@
 // PA Jacobs
 // 2022-02-02
 //
-module interp;
+module puffin.interp;
 
 import std.format;
 import std.math;
 
-import geom;
+import puffin.cell;
+import puffin.config;
+import puffin.face;
+import puffin.flow;
+
 import gas;
 import gasdyn.gasflow;
-import config;
-import flow;
-import face;
-import cell;
+import geom;
 
 
 @nogc

--- a/src/puffin/lorikeet_main.d
+++ b/src/puffin/lorikeet_main.d
@@ -5,19 +5,19 @@
 // 2022-12-12 Adapt the Puffin and Chicken codes into Lorikeet.
 //
 
+import std.algorithm;
+import std.conv;
+import std.file;
+import std.getopt;
+import std.math;
+import std.parallelism;
+import std.path;
 import std.stdio;
 import std.string;
-import std.file;
-import std.path;
-import std.getopt;
-import std.conv;
-import std.algorithm;
-import std.parallelism;
-import std.math;
 
-import config;
-import transient_calc;
-import fluidblock;
+import puffin.config;
+import puffin.fluidblock;
+import puffin.transient_calc;
 
 int main(string[] args)
 {

--- a/src/puffin/marching_calc.d
+++ b/src/puffin/marching_calc.d
@@ -3,25 +3,26 @@
 // PA Jacobs
 // 2022-01-22
 //
-module marching_calc;
+module puffin.marching_calc;
 
+import std.algorithm;
 import std.conv;
+import std.datetime;
+import std.file;
+import std.format;
+import std.json;
+import std.math;
+import std.parallelism;
+import std.range;
 import std.stdio;
 import std.string;
-import std.json;
-import std.file;
-import std.datetime;
-import std.format;
-import std.range;
-import std.math;
-import std.algorithm;
-import std.parallelism;
 
-import util.json_helper;
+import puffin.config;
+import puffin.streamtube;
+
 import geom;
-import config;
-import streamtube;
 import kinetics.init_thermochemical_reactor;
+import util.json_helper;
 
 // We use __gshared so that several threads may access
 // the following array concurrently.

--- a/src/puffin/puffin_main.d
+++ b/src/puffin/puffin_main.d
@@ -5,19 +5,19 @@
 // 2022-01-21 Start code.
 //
 
+import std.algorithm;
+import std.conv;
+import std.file;
+import std.getopt;
+import std.math;
+import std.parallelism;
+import std.path;
 import std.stdio;
 import std.string;
-import std.file;
-import std.path;
-import std.getopt;
-import std.conv;
-import std.algorithm;
-import std.parallelism;
-import std.math;
 
-import config;
-import marching_calc;
-import streamtube;
+import puffin.config;
+import puffin.marching_calc;
+import puffin.streamtube;
 
 int main(string[] args)
 {

--- a/src/puffin/streamtube.d
+++ b/src/puffin/streamtube.d
@@ -3,31 +3,31 @@
 // PA Jacobs
 // 2022-01-22
 //
-module streamtube;
+module puffin.streamtube;
 
+import std.algorithm;
 import std.conv;
+import std.format;
+import std.json;
+import std.math;
+import std.range;
 import std.stdio;
 import std.string;
-import std.json;
-import std.format;
-import std.range;
-import std.math;
-import std.algorithm;
 
+import puffin.cell;
+import puffin.config;
+import puffin.face;
+import puffin.flow;
+import puffin.flux;
+
+import gas;
+import geom;
+import kinetics;
 import nm.schedule;
 import util.json_helper;
-import geom;
-import gas;
-import kinetics;
-import config;
-import flow;
-import cell;
-import face;
-import flux;
 
 
-enum BCCode {wall=0, exchange=1}; // To decide what to do at the lower and upper boundary.
-
+enum BCCode {wall=0, exchange=1} // To decide what to do at the lower and upper boundary.
 
 class StreamTube {
 public:

--- a/src/puffin/transient_calc.d
+++ b/src/puffin/transient_calc.d
@@ -3,28 +3,29 @@
 // PA Jacobs
 // 2022-12-12: Adapt from Puffin and Chicken codes.
 //
-module transient_calc;
+module puffin.transient_calc;
 
+import core.stdc.math: HUGE_VAL;
+import std.algorithm;
 import std.conv;
+import std.datetime;
+import std.file;
+import std.format;
+import std.json;
+import std.math;
+import std.parallelism;
+import std.range;
 import std.stdio;
 import std.string;
-import std.json;
-import std.file;
-import std.datetime;
-import std.format;
-import std.range;
-import std.math;
-import std.algorithm;
-import core.stdc.math: HUGE_VAL;
-import std.parallelism;
 
-import util.json_helper;
-import geom;
+import puffin.config;
+import puffin.flow;
+import puffin.fluidblock;
+
 import gas;
+import geom;
 import kinetics;
-import config;
-import flow;
-import fluidblock;
+import util.json_helper;
 
 // We use __gshared so that several threads may access
 // the following array concurrently.

--- a/src/quodas/source/block.d
+++ b/src/quodas/source/block.d
@@ -1,18 +1,22 @@
 // block.d
-module block;
-import std.stdio;
+module quodas.block;
+
 import std.conv;
-import std.math;
 import std.file;
 import std.format;
+import std.math;
+import std.stdio;
 import std.string;
-import config;
-import finite_volume;
+
+import quodas.config;
+import quodas.derivative;
+import quodas.finite_volume;
+import quodas.flux;
+import quodas.linalg;
+
 import nm.number;
 import ntypes.complex;
-import derivative;
-import flux;
-import linalg;
+
 
 class Block {
 public:

--- a/src/quodas/source/config.d
+++ b/src/quodas/source/config.d
@@ -1,10 +1,11 @@
 // config.d
-module config;
-import std.json;
-import std.conv;
-import std.stdio;
-import std.file;
+module quodas.config;
+
 import core.stdc.stdlib : exit;
+import std.conv;
+import std.file;
+import std.json;
+import std.stdio;
 
 // define some global values
 immutable size_t nprimitive = 3; // number of primitive flow variables

--- a/src/quodas/source/derivative.d
+++ b/src/quodas/source/derivative.d
@@ -1,13 +1,16 @@
 // derivative.d
-module derivative;
-import std.stdio;
+module quodas.derivative;
+
 import std.conv;
 import std.math;
-import config;
+import std.stdio;
+
+import quodas.block;
+import quodas.config;
+import quodas.finite_volume;
+import quodas.linalg;
+
 import nm.number;
-import block;
-import finite_volume;
-import linalg;
 
 class Derivative {
 public:

--- a/src/quodas/source/finite_volume.d
+++ b/src/quodas/source/finite_volume.d
@@ -1,8 +1,10 @@
 // finite_volume.d
-module finite_volume;
-import std.stdio;
+module quodas.finite_volume;
+
 import std.conv;
 import std.math;
+import std.stdio;
+
 import nm.number;
 import ntypes.complex;
 

--- a/src/quodas/source/flow_solver.d
+++ b/src/quodas/source/flow_solver.d
@@ -1,9 +1,11 @@
 // flow_solver.d
-module flowsolve;
-import ntypes.complex;
+module quodas.flow_solver;
+
+import quodas.block;
+import quodas.config;
+
 import nm.number;
-import config;
-import block;
+import ntypes.complex;
 
 class Solver {
 private:    

--- a/src/quodas/source/flux.d
+++ b/src/quodas/source/flux.d
@@ -1,8 +1,11 @@
 // flux.d
-module flux;
+module quodas.flux;
+
 import std.conv;
 import std.math;
-import finite_volume;
+
+import quodas.finite_volume;
+
 import nm.number;
 import ntypes.complex;
 

--- a/src/quodas/source/linalg.d
+++ b/src/quodas/source/linalg.d
@@ -1,12 +1,13 @@
 // matrix.d
-module linalg;
+module quodas.linalg;
 
-import std.stdio;
-import std.math;
 import std.conv;
 import std.file;
 import std.format;
+import std.math;
+import std.stdio;
 import std.string;
+
 import nm.number;
 
 void prep_matrix(ref double[][] a, size_t ncols, size_t nrows) {

--- a/src/quodas/source/main.d
+++ b/src/quodas/source/main.d
@@ -6,15 +6,16 @@
  location: Seoul, South Korea
 */
 
-import std.stdio;
-import std.string;
-import std.file;
 import std.conv;
 import std.exception;
-import config;
-import flowsolve;
-import optimizer;
-import block;
+import std.file;
+import std.stdio;
+import std.string;
+
+import quodas.block;
+import quodas.config;
+import quodas.flow_solver;
+import quodas.optimizer;
 
 void main() {
     Params params;

--- a/src/quodas/source/optimizer.d
+++ b/src/quodas/source/optimizer.d
@@ -1,16 +1,19 @@
 // optimizer.d
-module optimizer;
-import std.stdio;
+module quodas.optimizer;
+
 import std.conv;
 import std.math;
-import config;
+import std.stdio;
+
+import quodas.block;
+import quodas.config;
+import quodas.derivative;
+import quodas.finite_volume;
+import quodas.flow_solver;
+import quodas.linalg;
+
 import nm.number;
 import ntypes.complex;
-import flowsolve;
-import finite_volume;
-import block;
-import derivative;
-import linalg;
 
 class Optimizer {
 public:

--- a/src/slf/core.d
+++ b/src/slf/core.d
@@ -1,5 +1,5 @@
 /*
-    slf.d: a steady laminar flamelet calculator by NNG.
+    slf: a steady laminar flamelet calculator by NNG.
 
     References:
       "A Consistent Flamelet Formulation for Non-Premixed Combustion Considering
@@ -12,7 +12,7 @@
        LLNL-JRNL-807545, March 23, 2020
 */
 
-module slf;
+module slf.core;
 
 import core.sys.posix.signal;
 import core.thread;
@@ -526,21 +526,3 @@ double[] get_derivatives_from_adjoint(number[] U, number[] U2nd, number[] R, num
     pm.p.im = 0.0;
     return dUdp;
 }
-
-int main(string[] args)
-{
-    int exitFlag = 0;
-    string name = "slf";
-    if (args.length>1) name = args[1];
-    name = name.chomp(".yaml");
-
-    auto flame = new Flame(name);
-    flame.set_initial_condition();
-
-    exitFlag = flame.run();
-
-    flame.save_solution();
-    flame.save_log();
-
-    return exitFlag;
-} // end main()

--- a/src/slf/cwrap.d
+++ b/src/slf/cwrap.d
@@ -13,7 +13,7 @@ import std.conv;
 import std.stdio;
 import std.string;
 
-import slf;
+import slf.core;
 
 Flame flame;
 

--- a/src/slf/cwrap.d
+++ b/src/slf/cwrap.d
@@ -9,9 +9,9 @@ Notes:
 
 import core.runtime;
 import core.stdc.string;
-import std.string;
-import std.stdio;
 import std.conv;
+import std.stdio;
+import std.string;
 
 import slf;
 

--- a/src/slf/io.d
+++ b/src/slf/io.d
@@ -1,18 +1,20 @@
 // io.d: reading and writing and storage for slf
 // @author: NNG
 
-module io;
+module slf.io;
 
-import std.stdio;
-import std.format;
-import std.string;
 import std.conv;
+import std.format;
+import std.stdio;
+import std.string;
 
 import dyaml;
+
+import slf.misc;
+
 import gas;
-import ntypes.complex;
 import nm.number;
-import misc;
+import ntypes.complex;
 
 struct Config {
     string gas_file_name;

--- a/src/slf/linalg.d
+++ b/src/slf/linalg.d
@@ -1,18 +1,18 @@
 // Linear algebra for solving block sparse tridiagonal systems
 // for slf, @author: NNG
 
-module linalg;
+module slf.linalg;
 
-import std.stdio;
-import std.format;
-import std.string;
 import std.conv;
+import std.format;
+import std.stdio;
+import std.string;
 
-import io;
+import slf.io;
 
 import nm.bbla;
-import ntypes.complex;
 import nm.number;
+import ntypes.complex;
 
 void multiply_tridigonal_block_matrix(ref const Parameters pm, Matrix!(double)[3][] LHS, Matrix!(double)[] U, Matrix!(double)[] R){
     size_t neq = pm.neq;

--- a/src/slf/main.d
+++ b/src/slf/main.d
@@ -1,0 +1,25 @@
+/*
+    main.d: a basic executable entry-point to the slf calculator
+*/
+
+import std.string;
+
+import slf.core : Flame;
+
+int main(string[] args)
+{
+    int exitFlag = 0;
+    string name = "slf";
+    if (args.length>1) name = args[1];
+    name = name.chomp(".yaml");
+
+    auto flame = new Flame(name);
+    flame.set_initial_condition();
+
+    exitFlag = flame.run();
+
+    flame.save_solution();
+    flame.save_log();
+
+    return exitFlag;
+} // end main()

--- a/src/slf/makefile
+++ b/src/slf/makefile
@@ -182,14 +182,14 @@ $(LIBGASF):
 $(LIBEQC):
 	cd $(EQC_DIR); make
 
-slf: slf.d $(SLF_FILES) \
+slf: main.d core.d $(SLF_FILES) \
 	$(DYAML_FILES) $(TINYENDIAN_FILES) \
 	$(GAS_FILES) $(EQC_SRC_FILES) $(LIBEQC) $(LIBGASF) $(LIBLUA) $(GZIP_FILES) \
 	$(KINETICS_FILES) $(GAS_LUA_FILES) $(KINETICS_LUA_FILES) \
 	$(NM_FILES) $(NTYPES_FILES) $(UTIL_FILES)
 	$(DMD) $(DFLAGS) $(OF)slf \
 		$(DVERSION)complex_numbers \
-		slf.d \
+		main.d core.d \
 		$(SLF_FILES) $(DYAML_FILES) $(TINYENDIAN_FILES) \
 		$(GAS_FILES) $(EQC_SRC_FILES) $(GZIP_FILES) \
 		$(UTIL_FILES) $(NM_FILES) $(NTYPES_FILES) \
@@ -197,14 +197,14 @@ slf: slf.d $(SLF_FILES) \
 		$(LIBEQC) $(LIBGASF) $(LIBLUA) \
 		$(DLINKFLAGS)
 
-libslf.so: cwrap.d slf.d $(SLF_FILES) \
+libslf.so: cwrap.d core.d $(SLF_FILES) \
 	$(DYAML_FILES) $(TINYENDIAN_FILES) \
 	$(GAS_FILES) $(EQC_SRC_FILES) $(LIBEQC) $(LIBGASF) $(LIBLUA) $(GZIP_FILES) \
 	$(KINETICS_FILES) $(GAS_LUA_FILES) $(KINETICS_LUA_FILES) \
 	$(NM_FILES) $(NTYPES_FILES) $(UTIL_FILES)
 	$(DMD) -c cwrap.d $(PIC) $(DFLAGS) -op \
 		$(DVERSION)complex_numbers \
-		slf.d \
+		core.d \
 		$(SLF_FILES) $(DYAML_FILES) $(TINYENDIAN_FILES) \
 		$(GAS_FILES) $(EQC_SRC_FILES) $(GZIP_FILES) \
 		$(UTIL_FILES) $(NM_FILES) $(NTYPES_FILES) \
@@ -212,7 +212,7 @@ libslf.so: cwrap.d slf.d $(SLF_FILES) \
 		$(LIBEQC) $(LIBGASF) $(LIBLUA)
 	$(DMD) $(OF)libslf.so cwrap.o $(PIC) $(DFLAGS) -op -shared \
 		$(DVERSION)complex_numbers \
-		slf.d \
+		core.d \
 		$(SLF_FILES) $(DYAML_FILES) $(TINYENDIAN_FILES) \
 		$(GAS_FILES) $(EQC_SRC_FILES) $(GZIP_FILES) \
 		$(UTIL_FILES) $(NM_FILES) $(NTYPES_FILES) \

--- a/src/slf/misc.d
+++ b/src/slf/misc.d
@@ -2,15 +2,15 @@
 // @author: NNG
 
 
-module misc;
+module slf.misc;
 
 import std.math;
 
-import io;
+import slf.io;
 
 import nm.bbla;
-import ntypes.complex;
 import nm.number;
+import ntypes.complex;
 
 
 /* This function borrowed from zero_rk:

--- a/src/slf/slf.d
+++ b/src/slf/slf.d
@@ -14,20 +14,20 @@
 
 module slf;
 
-import std.stdio;
-import std.math;
-import std.mathspecial;
-import std.format;
-import std.string;
+import core.sys.posix.signal;
+import core.thread;
 import std.conv;
 import std.datetime.stopwatch : StopWatch;
-import core.thread;
-import core.sys.posix.signal;
+import std.format;
+import std.math;
+import std.mathspecial;
+import std.stdio;
+import std.string;
 
 // slf specific modules
-import io;
-import linalg;
-import misc;
+import slf.io;
+import slf.linalg;
+import slf.misc;
 
 import gas;
 import gas.physical_constants;


### PR DESCRIPTION
Using proper prefixes will allow D compilers to automatically include source files without explicit inclusion, only using combinations of `-I` and `-i`. This is in preparation for a simplification of makefiles and compiler recipes. 

**Note:** the `eilmer` project is excluded from any changes, as it is in maintenance only mode.