### PR TITLE
Fixes a bracket placement error in kinetics/exchange_chemistry_coupling.d Line172: The R_universal const…

### DIFF
--- a/src/kinetics/exchange_chemistry_coupling.d
+++ b/src/kinetics/exchange_chemistry_coupling.d
@@ -169,7 +169,8 @@ class MarroneTreanorDissociation : ExchangeChemistryCoupling {
     number Gappear(in GasState gs) {
         // compute the energy per dissociation, but with T_v = T_tr
         number T_F_inv = -1./_U;
-        return R_universal * (_theta_v / (exp(_theta_v * T_F_inv) - 1.) - _D / (exp(_D / R_universal * T_F_inv) - 1.));
+        // Corrected version: R_universal applies only to the first term
+        return R_universal * _theta_v / (exp(_theta_v * T_F_inv) - 1.) - _D / (exp(_D / R_universal * T_F_inv) - 1.);
     }
 
 private:


### PR DESCRIPTION
## Description
This PR fixes a bracket placement error in the `Gappear` method of the `MarroneTreanorDissociation` class.

## Problem
Line 172 had incorrect parentheses that caused `R_universal` to multiply the entire expression instead of just the first term.

**Before (incorrect):**
```d
return R_universal * (_theta_v / (exp(_theta_v * T_F_inv) - 1.) - _D / (exp(_D / R_universal * T_F_inv) - 1.));
```
**After (correct):**
```d
return R_universal * _theta_v / (exp(_theta_v * T_F_inv) - 1.) - _D / (exp(_D / R_universal * T_F_inv) - 1.);
```

## Impact
This error would affect energy calculations in chemistry-vibration coupling for dissociation reactions using the Marrone-Treanor model. 