### PR TITLE
lmr: Reinstated config option to select specific flux calculator for forming preconditioner

### DIFF
--- a/src/lmr/fluidblock.d
+++ b/src/lmr/fluidblock.d
@@ -1478,7 +1478,7 @@ public:
         */
     } // end jacobian_nonzero_pattern()
 
-    void evaluate_jacobian()
+    void evaluate_jacobian(FluxCalculator fluxCalculatorForPreconditioner)
     {
         /*
           Higher level method used to evaluate the flow Jacobian attached to the FluidBlock object.
@@ -1489,7 +1489,7 @@ public:
 
         // temporarily change flux calculator
         auto flux_calculator_save = myConfig.flux_calculator;
-        myConfig.flux_calculator = myConfig.flux_calculator; // TODO: add preconditionMatrixFluxCalculator back
+        myConfig.flux_calculator = fluxCalculatorForPreconditioner;
 
         // temporarily change interpolation order
         shared int interpolation_order_save = GlobalConfig.interpolation_order;

--- a/src/lmr/lua-modules/nkconfig.lua
+++ b/src/lmr/lua-modules/nkconfig.lua
@@ -51,6 +51,7 @@ NewtonKrylovGlobalConfigHidden = {
    use_preconditioner = true,
    preconditioner_perturbation = 1.0e-30,
    preconditioner = "ilu",
+   preconditioner_flux_calculator = "NO_SELECTION_SUPPLIED",
    --
    -- ILU preconditioner settings
    --
@@ -154,6 +155,7 @@ local function writeNKConfigToFile(nkConfig, nkPhases, fileName)
    f:write(string.format('"use_preconditioner": %s,\n', tostring(nkConfig.use_preconditioner)))
    f:write(string.format('"preconditioner_perturbation": %.18e,\n', nkConfig.preconditioner_perturbation))
    f:write(string.format('"preconditioner": "%s",\n', nkConfig.preconditioner))
+   f:write(string.format('"preconditioner_flux_calculator": "%s",\n', nkConfig.preconditioner_flux_calculator))
    f:write(string.format('"ilu_fill": %d,\n', nkConfig.ilu_fill))
    f:write(string.format('"preconditioner_sub_iterations": %d,\n', nkConfig.preconditioner_sub_iterations))
    -- output and diagnostics


### PR DESCRIPTION

This config option relates specifically to the Newton-Krylov solver. It was an option available in Eilmer v4 and has now been ported across to v5.

JW and RJG worked together on this commit.