### PR TITLE
Fix Jacobian construction for k-omega turbulence model.

### DIFF
--- a/src/lmr/fluidblock.d
+++ b/src/lmr/fluidblock.d
@@ -1586,6 +1586,7 @@ public:
                 if (flowJacobian.spatial_order >= 2) {
                     foreach(cell; pcell.cell_list) { cell.gradients.copy_values_from(*(cell.gradients_save)); }
                 }
+                estimate_turbulence_viscosity(pcell.cell_list);
             } else {
                 // TODO: for structured grids employing a real-valued low-order numerical Jacobian as
                 // the precondition matrix the above code doesn't completely clean up the effect of the
@@ -1682,6 +1683,7 @@ public:
                                 foreach(cell; ghost_cell.cell_list) { cell.gradients.copy_values_from(*(cell.gradients_save)); }
                             }
                             ghost_cell.fs.clear_imaginary_components();
+                            estimate_turbulence_viscosity(pcell.cell_list);
                         } else {
                             // TODO: for structured grids employing a real-valued low-order numerical Jacobian as
                             // the precondition matrix the above code doesn't completely clean up the effect of the


### PR DESCRIPTION
Closes #165

Problem:
@uqngibbo identified that some members of the local cell stencil did not have 
their turbulent viscosity reset after a perturbation during Jacobian construction.

Solution:
Call estimate_turbulence_viscosity() for all cells in the local cell stencil to 
clear any residual perturbations during Jacobian construction.